### PR TITLE
Update v-ref syntax in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ import VueToast from 'vue-toast'
 
 
 new Vue({
-  template: '<div> <vue-toast v-ref="toast"></vue-toast> </div>',
+  template: '<div> <vue-toast v-ref:toast></vue-toast> </div>',
   components: {
     VueToast: VueToast
   },


### PR DESCRIPTION
Copying the example from the readme wasn't working with Vue 1.0.16. Updating to the [latest syntax](https://vuejs.org/api/#v-ref) works fine.
