### PR TITLE
v-ref no longer exists in Vue 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ import VueToast from 'vue-toast'
 
 
 new Vue({
-  template: '<div> <vue-toast v-ref:toast></vue-toast> </div>',
+  template: '<div> <vue-toast ref="toast"></vue-toast> </div>',
   components: {
     VueToast: VueToast
   },


### PR DESCRIPTION
v-ref has been replaced with ref=""

v-ref:toast would be ref="toast"